### PR TITLE
Add a status badge to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Confidential-ACI-Attestation
+# Confidential-ACI-Attestation [![CI](https://github.com/microsoft/confidential-aci-attestation/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/confidential-aci-attestation/actions/workflows/ci.yml) 
 
 ## Overview
 


### PR DESCRIPTION
### Why

It's useful to see the state of the CI tests on the main page of the repo