### PR TITLE
Bump c-aci-attestation version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,13 +21,13 @@ make
 ### Python Package
 
 ```
-pip install git+https://github.com/microsoft/confidential-aci-attestation@0.1.0#subdirectory=src/bindings/python
+pip install git+https://github.com/microsoft/confidential-aci-attestation@0.2.0#subdirectory=src/bindings/python
 ```
 
 ### Docker Image
 
 ```
-docker pull ghcr.io/microsoft/confidential-aci-attestation:0.1.0
+docker pull ghcr.io/microsoft/confidential-aci-attestation:0.2.0
 ```
 
 ## Usage

--- a/src/bindings/python/setup.py
+++ b/src/bindings/python/setup.py
@@ -26,7 +26,7 @@ class CustomBuild(_build_py):
 
 setup(
     name='attestation',
-    version='0.1.0',
+    version='0.2.0',
     description='Python bindings for the SNP attestation C core',
     packages=find_packages(where='.'),
     package_dir={'': '.'},


### PR DESCRIPTION
### Why

Despite having a 0.2.0 tag, the setup.py and installation instructions still refer to 0.1.0, so these need updating